### PR TITLE
FEAT: cleanup

### DIFF
--- a/offerID.go
+++ b/offerID.go
@@ -36,7 +36,7 @@ type OfferID struct {
 func NewOfferID(s string) (*OfferID, error) {
 	var o OfferID
 
-	b, err := base64.StdEncoding.DecodeString(s)
+	b, err := base64.RawURLEncoding.DecodeString(s)
 	if err != nil {
 		return nil, err
 	}
@@ -70,7 +70,7 @@ func (o *OfferID) AsString() (string, error) {
 		return "", err
 	}
 
-	return base64.StdEncoding.EncodeToString(b), nil
+	return base64.RawURLEncoding.EncodeToString(b), nil
 }
 
 func (o *OfferID) writeToBuffer(b *bytes.Buffer) error {

--- a/services.go
+++ b/services.go
@@ -101,11 +101,11 @@ func configreSwiftStore(swiftConfig swift.Configuration) swift.Store {
 		os.Getenv("AZURE_STORAGE_ACCOUNT"),
 		os.Getenv("AZURE_STORAGE_ACCESS_KEY")
 	if len(azureAccountName) > 0 || len(azureAccountKey) > 0 {
+		log.Printf("SWIFT: Using Azure Table Storage")
 		if len(azureAccountName) == 0 || len(azureAccountKey) == 0 {
 			panic(errors.New("Either the AZURE_STORAGE_ACCOUNT or " +
-				"AZURE_STORAGE_ACCESS_KEY environment variable is not set"))
+				"AZURE_STORAGE_ACCESS_KEY environment variable is not set."))
 		}
-		log.Printf("SWIFT: Using Azure Table Storage")
 		swiftStore, err = swift.NewAzure(
 			azureAccountName,
 			azureAccountKey)
@@ -121,7 +121,8 @@ func configreSwiftStore(swiftConfig swift.Configuration) swift.Store {
 	}
 
 	if swiftStore == nil {
-		panic(errors.New("SWIFT: store not configured"))
+		panic(errors.New("SWIFT: store not configured, have you set AWS " +
+			" OR Azure Storage Table credentials?"))
 	}
 
 	return swiftStore


### PR DESCRIPTION
- Use base64 URL encoding always when dealing with base64 strings to prevent issues when transmitting base64 strings over the web.
- Use environment variables for azure storage and AWS store services.
