### PR TITLE
FEAT: Modified the update operation to use the homenode feature of SWIFT to prevent the home node check when adding new values to the network.

### DIFF
--- a/handlerFetch.go
+++ b/handlerFetch.go
@@ -42,7 +42,7 @@ func handlerFetch(s *services) http.HandlerFunc {
 			log.Println(r.URL.String() + "?" + r.Form.Encode())
 		}
 
-		// Validate the set the return URL.
+		// Validate and set the return URL.
 		err = swift.SetURL("returnUrl", "returnUrl", &r.Form)
 		if err != nil {
 			returnAPIError(&s.config, w, err, http.StatusBadRequest)

--- a/handlerFetch.go
+++ b/handlerFetch.go
@@ -77,30 +77,43 @@ func handlerFetch(s *services) http.HandlerFunc {
 // provided by the caller for this situation. If no SWID is provided then SWAN
 // will assign a new random one.
 func setDefaults(s *services, r *http.Request) {
-	t := s.config.DeleteDate().Format("2006-01-02")
+	t := s.config.DeleteDate()
 	q := &r.Form
 
-	// Process any exist SWID or preference data provided by the caller.
-	setSWID(s, r)
-	setPerf(s, r)
+	// Process any exist SWID, preference or stop data provided by the caller.
+	setSWID(s, r, t)
+	setPerf(s, r, t)
+	setStop(s, r, t)
 
-	// Use the other values provided.
-	q.Set(fmt.Sprintf("email<%s", t), "")
-	q.Set(fmt.Sprintf("stop<%s", t), q.Get("stop"))
+	// Get the email address either to return as the raw value, or to turn into
+	// a SID once it's been fetched. Always favour the most recent email address
+	// available across the network.
+	q.Set("email>", "")
 
 	// Delete any common parameters that might have been included in the request
 	// that we do not need. Avoids SWIFT trying to process then as keys.
 	q.Del("sid")
-	q.Del("stop")
 	q.Del("val")
+}
+
+// setStop uses the values provided and will add them to any other stop values
+// already contained in the network.
+func setStop(s *services, r *http.Request, t time.Time) {
+	if r.Form.Get("stop") != "" {
+		r.Form.Set(
+			fmt.Sprintf("stop+%s", t.Format("2006-01-02")),
+			r.Form.Get("stop"))
+	} else {
+		r.Form.Set("stop+", "")
+	}
+	r.Form.Del("stop")
 }
 
 // setPerf gets the value of perf from the request and verifies it's a valid
 // OWID. If it is valid then use it as the default value if the SWAN network
 // does not contain a value. If it is not valid then an empty value will be
 // used to indicate that the user has not provided any preferences.
-func setPerf(s *services, r *http.Request) {
-	var t time.Time         // The expiry time in SWIFT for the value being written
+func setPerf(s *services, r *http.Request, t time.Time) {
 	v := r.Form.Get("pref") // The value for the Perf. to use if one not found
 	o, err := owid.FromBase64(v)
 	if err != nil {
@@ -118,7 +131,9 @@ func setPerf(s *services, r *http.Request) {
 			// Change the expiry time to be based on the Perf. creation date.
 			t = o.Date.AddDate(0, 0, s.config.DeleteDays)
 
-			// If the value has already expired then don't use it.
+			// If the value has already expired then don't use it. If not then
+			// use it as the value if the network does not currently contain a
+			// value.
 			if time.Now().UTC().After(t) {
 				v = ""
 			}
@@ -127,13 +142,22 @@ func setPerf(s *services, r *http.Request) {
 		}
 	}
 
-	if v == "" {
-		t = s.config.DeleteDate()
-	}
-
 	// Set the value in the SWIFT storage operation, and remove the perf from
 	// the form.
-	r.Form.Set(fmt.Sprintf("pref<%s", t.Format("2006-01-02")), v)
+	if v != "" {
+
+		// There is an existing preference stored by the caller. Use this value
+		// if the network does not currently contain a more recent version.
+		r.Form.Set(fmt.Sprintf("pref>%s", t.Format("2006-01-02")), v)
+
+	} else {
+
+		// There is no existing preference available. Therefore retrieve the
+		// newest value contained in the network.
+		r.Form.Set("pref>", "")
+	}
+
+	// Remove pref key as this is not valid for a SWIFT operation.
 	r.Form.Del("pref")
 }
 
@@ -147,8 +171,7 @@ func setPerf(s *services, r *http.Request) {
 // be used by the SWAN Operators.
 // If none of the conditions are valid then a new SWID is created and used if
 // the SWAN network does not contain any other values.
-func setSWID(s *services, r *http.Request) {
-	var t time.Time         // The expiry time in SWIFT for the value being written
+func setSWID(s *services, r *http.Request, t time.Time) {
 	v := r.Form.Get("swid") // The value for the SWID to use if one not found
 	o, err := owid.FromBase64(v)
 	if err != nil {
@@ -166,7 +189,9 @@ func setSWID(s *services, r *http.Request) {
 			// Change the expiry time to be based on the SWID creation date.
 			t = o.Date.AddDate(0, 0, s.config.DeleteDays)
 
-			// If the value has already expired then don't use it.
+			// If the value has already expired then don't use it. If not then
+			// use it as the value if the network does not currently contain a
+			// value.
 			if time.Now().UTC().After(t) {
 				v = ""
 			}
@@ -175,21 +200,22 @@ func setSWID(s *services, r *http.Request) {
 		}
 	}
 
-	if v == "" {
+	// Set the value in the SWIFT storage operation, and remove the SWID from
+	// the form.
+	if v != "" {
 
-		// There is no valid SWID so create a new one.
-		c, err := createSWID(s, r)
-		if err != nil {
-			logNonCriticalError(s, err)
-		} else {
-			v = c.AsString()
-			t = s.config.DeleteDate()
-		}
+		// There is an existing SWID stored by the caller. Use this value if the
+		// network does not currently contain a more recent version.
+		r.Form.Set(fmt.Sprintf("swid>%s", t.Format("2006-01-02")), v)
+
+	} else {
+
+		// There is no existing SWID available. Therefore retrieve the newest
+		// value contained in the network.
+		r.Form.Set("swid>", "")
 	}
 
-	// Set the value in the SWIFT storate operation, and remove the SWID from
-	// the form.
-	r.Form.Set(fmt.Sprintf("swid<%s", t.Format("2006-01-02")), v)
+	// Remove swid key as this is not valid for a SWIFT operation.
 	r.Form.Del("swid")
 }
 

--- a/handlerStop.go
+++ b/handlerStop.go
@@ -40,6 +40,9 @@ func handlerStop(s *services) http.HandlerFunc {
 			return
 		}
 
+		// As this is an update operation do not use the home node alone.
+		r.Form.Set("useHomeNode", "false")
+
 		// Validate the set the return URL.
 		err := swift.SetURL("returnUrl", "returnUrl", &r.Form)
 		if err != nil {

--- a/handlerUpdate.go
+++ b/handlerUpdate.go
@@ -64,7 +64,7 @@ func handlerUpdate(s *services) http.HandlerFunc {
 		r.Form.Set(fmt.Sprintf("swid>%s", t), r.Form.Get("swid"))
 		r.Form.Set(fmt.Sprintf("email>%s", t), r.Form.Get("email"))
 		r.Form.Set(fmt.Sprintf("pref>%s", t), r.Form.Get("pref"))
-		r.Form.Set(fmt.Sprintf("stop<%s", t), "")
+		r.Form.Set(fmt.Sprintf("stop+%s", t), r.Form.Get("stop"))
 		r.Form.Del("swid")
 		r.Form.Del("email")
 		r.Form.Del("pref")

--- a/handlerUpdate.go
+++ b/handlerUpdate.go
@@ -35,6 +35,9 @@ func handlerUpdate(s *services) http.HandlerFunc {
 			return
 		}
 
+		// As this is an update operation do not use the home node alone.
+		r.Form.Set("useHomeNode", "false")
+
 		// Validate and set the return URL.
 		err := swift.SetURL("returnUrl", "returnUrl", &r.Form)
 		if err != nil {


### PR DESCRIPTION
Prevents the User Interface Provider update operation from only writing data to the home node and not the rest of the network.